### PR TITLE
fix(FEC-8165): When seeking to 50% of the video, google analytics event of reach 25% shows a value of 50%

### DIFF
--- a/src/google-analytics.js
+++ b/src/google-analytics.js
@@ -156,21 +156,21 @@ export default class GoogleAnalytics extends BasePlugin {
     };
     if (this.player.config.sources.type !== this.player.MediaType.LIVE) {
       const percent = this.player.currentTime / this.player.duration;
-      if (!this._timePercentEvent.PLAY_REACHED_25 && percent >= 0.25) {
+      if (!this._timePercentEvent.PLAY_REACHED_25 && percent >= 0.25 && percent < 0.5) {
         this._timePercentEvent.PLAY_REACHED_25 = true;
         this._sendEvent({
           action: PCT_25_ACTION,
           ...getPctEventParams()
         });
       }
-      if (!this._timePercentEvent.PLAY_REACHED_50 && percent >= 0.5) {
+      if (!this._timePercentEvent.PLAY_REACHED_50 && percent >= 0.5 && percent < 0.75) {
         this._timePercentEvent.PLAY_REACHED_50 = true;
         this._sendEvent({
           action: PCT_50_ACTION,
           ...getPctEventParams()
         });
       }
-      if (!this._timePercentEvent.PLAY_REACHED_75 && percent >= 0.75) {
+      if (!this._timePercentEvent.PLAY_REACHED_75 && percent >= 0.75 && percent < 1) {
         this._timePercentEvent.PLAY_REACHED_75 = true;
         this._sendEvent({
           action: PCT_75_ACTION,


### PR DESCRIPTION
Added more precise condition (instead of just `> 25%` made it   `25 <  % < 50`)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
