### PR TITLE
fix(FEC-8605): change media event is triggered on first entry load

### DIFF
--- a/src/default-tracking.js
+++ b/src/default-tracking.js
@@ -33,7 +33,10 @@ export default {
     },
     CHANGE_SOURCE_ENDED: {
       action: 'change media',
-      value: 1
+      value: 1,
+      condition: function() {
+        return !this._firstEntry;
+      }
     },
     ENTER_FULLSCREEN: {
       action: 'enter full screen',

--- a/src/google-analytics.js
+++ b/src/google-analytics.js
@@ -50,6 +50,12 @@ export default class GoogleAnalytics extends BasePlugin {
   };
 
   /**
+   * Indicate whether its the first entry that is played
+   * @private
+   */
+  _firstEntry: boolean = true;
+
+  /**
    * @constructor
    * @param {string} name - The plugin name.
    * @param {Player} player - The player instance.
@@ -138,6 +144,7 @@ export default class GoogleAnalytics extends BasePlugin {
       });
     });
     this.eventManager.listen(this.player, this.player.Event.TIME_UPDATE, this._sendTimePercentAnalytic.bind(this));
+    this.eventManager.listenOnce(this.player, this.player.Event.CHANGE_SOURCE_ENDED, () => (this._firstEntry = false));
   }
 
   /**

--- a/test/src/google-analytics.spec.js
+++ b/test/src/google-analytics.spec.js
@@ -67,6 +67,10 @@ describe('Google Analytics Plugin', function() {
     }
   }
 
+  function verifyEventCondition(eventData, value) {
+    eventData[2].condition().should.equal(value);
+  }
+
   function verifyEventName(eventData, name) {
     eventData[1].should.equal(name);
   }
@@ -257,11 +261,23 @@ describe('Google Analytics Plugin', function() {
       player.notifyEnterFullscreen();
     });
 
+    it('should not send change media', done => {
+      player.addEventListener(player.Event.CHANGE_SOURCE_ENDED, () => {
+        verifyEventName(dataLayer[dataLayer.length - 1], 'change media');
+        verifyEventParams(dataLayer[dataLayer.length - 1], {label: `${CMpartnerId} | ${CMuiConfId} | ${CMid} | '${CMentryName}'`});
+        verifyEventValue(dataLayer[dataLayer.length - 1], 1);
+        verifyEventCondition(dataLayer[dataLayer.length - 1], false);
+        done();
+      });
+      player.configure(CMconfig);
+    });
+
     it('should send change media', done => {
       player.addEventListener(player.Event.CHANGE_SOURCE_ENDED, () => {
         verifyEventName(dataLayer[dataLayer.length - 1], 'change media');
         verifyEventParams(dataLayer[dataLayer.length - 1], {label: `${CMpartnerId} | ${CMuiConfId} | ${CMid} | '${CMentryName}'`});
         verifyEventValue(dataLayer[dataLayer.length - 1], 1);
+        verifyEventCondition(dataLayer[dataLayer.length - 1], true);
         done();
       });
       player.configure(CMconfig);


### PR DESCRIPTION
Added a condition to the `CHANGE_MEDIA` event.
The condition is based on the value of `firstEntry` property, which is also initialized on `CHANGE_SOURCE_ENDED `

### Description of the Changes

Please add a detailed description of the change, weather it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
