### PR TITLE
fix(SUP-46750):(Salesforce+) GDPR on embeds for Path

### DIFF
--- a/src/google-analytics.js
+++ b/src/google-analytics.js
@@ -64,15 +64,19 @@ export default class GoogleAnalytics extends BasePlugin {
    */
   constructor(name: string, player: Player, config: Object) {
     super(name, player, config);
-    if (this.config.trackingId || this.config.trackingGA4Id) {
-      this._init();
-      this._addBindings();
-      this._sendEvent({
-        action: WIDGET_LOADED_ACTION,
-        category: this._getValue(this.config.tracking.category)
-      });
+    if (document.cookie) {
+      if (this.config.trackingId || this.config.trackingGA4Id) {
+        this._init();
+        this._addBindings();
+        this._sendEvent({
+          action: WIDGET_LOADED_ACTION,
+          category: this._getValue(this.config.tracking.category)
+        });
+      } else {
+        this.logger.warn('No Google Analytics tracking ID provided. Tracking aborted');
+      }
     } else {
-      this.logger.warn('No Google Analytics tracking ID provided. Tracking aborted');
+      this.logger.warn('No cookies enabled. Tracking aborted');
     }
   }
 

--- a/test/src/google-analytics.spec.js
+++ b/test/src/google-analytics.spec.js
@@ -7,13 +7,13 @@ const targetId = 'player-placeholder_google-analytics.spec';
 
 describe('Google Analytics Plugin', function () {
   let player;
-  const id = '1_rwbj3j0a';
-  const partnerId = 1068292;
+  const id = '0_fnkamt8x';
+  const partnerId = 243342;
   const uiConfId = 123456;
   const entryName = 'some name';
 
-  const CMid = '1_fdsfds78';
-  const CMpartnerId = 876543;
+  const CMid = '0_uka1msg4';
+  const CMpartnerId = 243342;
   const CMuiConfId = 654321;
   const CMentryName = 'change media name';
 


### PR DESCRIPTION
issue:
when cookies is disabled or deleted google analytics still send information

solution:
check if cookies exist, if not then do not send anything to google analytics

solve [SUP-46750](https://kaltura.atlassian.net/browse/SUP-46750)

[SUP-46750]: https://kaltura.atlassian.net/browse/SUP-46750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ