### PR TITLE
Fix tests and add scripts test:prepare and test:watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "prettier:fix": "prettier --write .",
     "pushTaggedRelease": "git push --follow-tags --no-verify origin master",
     "release": "standard-version",
+    "test:prepare": "yarn run build && yes | cp -i ./dist/playkit-google-analytics.js ./cypress/public/plugin.js",
+    "test:watch": "yarn run test:prepare && cypress open",
     "test": "NODE_ENV=test karma start --color --mode development",
     "watch": "webpack --progress --colors --watch --mode development"
   },

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "prettier:fix": "prettier --write .",
     "pushTaggedRelease": "git push --follow-tags --no-verify origin master",
     "release": "standard-version",
-    "test:prepare": "yarn run build && yes | cp -i ./dist/playkit-google-analytics.js ./cypress/public/plugin.js",
-    "test:watch": "yarn run test:prepare && cypress open",
+    "test:prepare": "npm run build && copyfiles -f ./dist/playkit-google-analytics.js ./dist/playkit-google-analytics.js.map ./cypress/public",
+    "test:watch": "npm run test:prepare && npm run cy:open",
     "test": "NODE_ENV=test karma start --color --mode development",
     "watch": "webpack --progress --colors --watch --mode development"
   },

--- a/test/setup/prepare-test-environment.js
+++ b/test/setup/prepare-test-environment.js
@@ -12,6 +12,7 @@ export function prepareTestEnvironment() {
   global.expect = chai.expect;
   global.should = chai.should;
   global.sinon = sinon;
+  document.cookie = 'test=1';
 }
 
 export default prepareTestEnvironment;


### PR DESCRIPTION
**Issue 1:** Missing script `test:prepare` caused canary to fail.
**Fix 1:** Add scripts` test:prepare` and `test:watch`

**Issue 2:**  `src/google-analytics.js` guards all initialization with `if (document.cookie)`. In the headless Chrome test environment, `document.cookie` returns an empty string (falsy), so `_init()` never runs, `window.dataLayer` is never created, and all tests that reference `dataLayer` fail.
**Fix 1:** Added `document.cookie = 'test=1'` to `test/setup/prepare-test-environment.js` so `document.cookie` is truthy before any tests run.  