### PR TITLE
Fix build CI/CD

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "scripts": {
     "preinstall": "npx --yes --prefer-online --registry=https://npm.pkg.github.com --package @kaltura/kaltura-tools@latest kaltura-tools check --root=.",
     "prebuild": "npm run clean",
-    "build": "webpack --mode production",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider webpack --mode production",
     "clean": "rm -rf ./dist",
-    "dev": "webpack-dev-server --mode development",
+    "dev": "NODE_OPTIONS=--openssl-legacy-provider webpack-dev-server --mode development",
     "eslint": "eslint . --color",
     "flow": "flow check",
     "precommit": "lint-staged",
@@ -37,8 +37,8 @@
     "release": "standard-version",
     "test:prepare": "npm run build && copyfiles -f ./dist/playkit-google-analytics.js ./dist/playkit-google-analytics.js.map ./cypress/public",
     "test:watch": "npm run test:prepare && npm run cy:open",
-    "test": "NODE_ENV=test karma start --color --mode development",
-    "watch": "webpack --progress --colors --watch --mode development"
+    "test": "NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=test karma start --color --mode development",
+    "watch": "NODE_OPTIONS=--openssl-legacy-provider webpack --progress --colors --watch --mode development"
   },
   "lint-staged": {
     "*.{js,jsx}": [


### PR DESCRIPTION
**Root cause:**
webpack 4 uses the legacy OpenSSL MD4 hash algorithm, which Node.js 17+ disabled by default.

**Solution:**
`NODE_OPTIONS=--openssl-legacy-provider` re-enables it.
Since the workflows call into shared reusable workflows in "kaltura/ovp-pipelines-pub" and "kaltura/playkit-js-common", need to set up the flag in package.json scripts - it takes effect regardless of which Node version the runner uses, and doesn't require changes to the shared pipeline definitions.